### PR TITLE
update frontend Dockerifle to 22.16.0

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.20.4-alpine as builder
+FROM node:22.16.0-alpine as builder
 
 WORKDIR /app
 


### PR DESCRIPTION
Title（标题）：update frontend Dockerifle to 22.16.0

Description（描述）：目前使用的18版本在构建镜像时，安装部分依赖报错。解决方案：更换20以上版本
`110.7  ERR_PNPM_UNSUPPORTED_ENGINE  Unsupported environment (bad pnpm and/or Node.js version)
110.7 
110.7 This error happened while installing the dependencies of mockjs@1.1.0
110.7 
110.7 Your Node version is incompatible with "commander@14.0.0".
110.7 
110.7 Expected version: >=20
110.7 Got: v18.20.4
110.7 
110.7 This is happening because the package's manifest has an engines.node field specified.
110.7 To fix this issue, install the required Node version.`

关联 Issue（无）：